### PR TITLE
merge updates from dev

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -20,7 +20,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        conda create --name base pyqtgraph pyside6 specutils astropy -c conda-forge 
+        conda update pyqtgraph pyside6 specutils astropy -c conda-forge 
     - name: Lint with flake8
       run: |
         conda install flake8

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -20,7 +20,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        conda env update --file environment.yml --name base
+        conda env update pyqtgraph pyside6 specutils astropy -c conda-forge --name base
     - name: Lint with flake8
       run: |
         conda install flake8

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -28,7 +28,7 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        conda install pytest
-        pytest
+    # - name: Test with pytest
+    #   run: |
+    #     conda install pytest
+    #     pytest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,0 +1,34 @@
+name: Python Package using Conda
+
+on: [push]
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        conda env update --file environment.yml --name base
+    - name: Lint with flake8
+      run: |
+        conda install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        conda install pytest
+        pytest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -20,7 +20,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        conda env update pyqtgraph pyside6 specutils astropy -c conda-forge --name base
+        conda create --name base pyqtgraph pyside6 specutils astropy -c conda-forge 
     - name: Lint with flake8
       run: |
         conda install flake8

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -20,7 +20,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        conda update pyqtgraph pyside6 specutils astropy -c conda-forge 
+        conda install pyqtgraph pyside6 specutils astropy -c conda-forge -y
     - name: Lint with flake8
       run: |
         conda install flake8

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="specbox",
-    version="0.1.0-beta",
+    version="0.1.1",
     author="Yuming Fu",
     author_email="fuympku@outlook.com",
     description="specbox - A simple tool to manipulate and visualize optical spectra for astronomical research.",

--- a/specbox/qtmodule/qtsir1d.py
+++ b/specbox/qtmodule/qtsir1d.py
@@ -123,9 +123,7 @@ class PGSpecPlot(pg.PlotWidget):
     def plot_single(self):
         spec = self.spec
         # If history contains a saved z_vi for this spectrum, use it.
-        if spec.objid in self.history:
-            spec.z_vi = self.history[spec.objid][4]
-        elif spec.z_vi == 0 and spec.z_ph > 0:
+        if spec.z_vi == 0 and spec.z_ph > 0:
             spec.z_vi = spec.z_ph
         z_vi = spec.z_vi
         z_gaia = spec.z_gaia
@@ -175,6 +173,8 @@ class PGSpecPlot(pg.PlotWidget):
         self.clear()
         spec = self.SpecClass(specfile, ext=self.counter + 1)
         self.spec = spec
+        if spec.objid in self.history:
+            spec.z_vi = self.history[spec.objid][4]
         self.update_slider_and_spin()  
         self.plot_single()
         self.counter += 1
@@ -187,6 +187,8 @@ class PGSpecPlot(pg.PlotWidget):
             self.clear()
             spec = self.SpecClass(specfile, ext=self.counter - 1)
             self.spec = spec
+            if spec.objid in self.history:
+                spec.z_vi = self.history[spec.objid][4]
             self.counter -= 1
             self.update_slider_and_spin()
             self.plot_single()
@@ -249,13 +251,18 @@ class PGSpecPlot(pg.PlotWidget):
             print("Class: LIKELY/Unusual QSO.")
             self.history[spec.objid] = [spec.objname, spec.ra, spec.dec, 'LIKELY', self.spec.z_vi]
         if event.key() == Qt.Key_R:
-            # Reset the plot to the original state
             self.clear()
             self.plot_single()   
-        # if the user presses the key combination Ctrl+Left, plot the previous spectrum
         if event.modifiers() & Qt.ControlModifier:
-            if event.key() == Qt.Key_Left:
-                self.plot_previous()
+            if event.key() == Qt.Key_R:
+                self.clear()
+                self.spec = self.SpecClass(self.specfile, ext=self.counter)
+                self.update_slider_and_spin()
+                self.plot_single() 
+        if event.key() == Qt.Key_Left:
+            self.plot_previous()
+        if event.key() == Qt.Key_Right:
+            self.plot_next()
 
 class PGSpecPlotApp(QApplication):
     def __init__(self, specfile, SpecClass=SpecEuclid1d, output_file='vi_output.csv', z_max=5.0, load_history=False):
@@ -293,12 +300,13 @@ class PGSpecPlotApp(QApplication):
         if self.plot.counter < self.len_list + 1:
             toplabel = layout.addLabel(
                 f"Press 'Q' for next spectrum, \t press no key or 'A' to set class as QSO(AGN),\n"
-                f"'S' to set class as STAR, \t\t 'G' to set class as GALAXY,\n"
-                f"'U' to set class as UNKNOWN, \t 'L' to set class as LIKELY/Unusual QSO,\n"
+                f"'U' to set class as UNKNOWN,\t 'L' for LIKELY/Unusual QSO,\t 'S' for STAR, and 'G' for GALAXY,\n"
                 f"'M' to get mouse position, \t\t 'Space' to get spectrum value at current wavelength.\n"
-                f"Use mouse scroll to zoom in/out, \t use mouse select to zoom in. \t" 
-                f"Press 'R' to reset the plot to the original state.\n"
-                f"Press 'Ctrl+Left' (MacOS: 'Command+Left') to plot the previous spectrum.", row=0, col=0, colspan=2)
+                f"Use mouse scroll to zoom in/out,\t use mouse select to zoom in.\n" 
+                f"Press 'R' to reset the zoom scale.\t"
+                f"Press 'Ctrl+R' to reset the plot with the initial z_vi.\n"
+                f"Press 'Left' to plot the previous spectrum,\t press 'Right' to plot the next spectrum.\n", 
+                row=0, col=0, colspan=2)
             toplabel.setFont(QFont("Arial", 16))
             toplabel.setFixedHeight(140)
             toplabel.setAlignment(Qt.AlignLeft)

--- a/specbox/qtmodule/qtsir1d.py
+++ b/specbox/qtmodule/qtsir1d.py
@@ -23,7 +23,7 @@ data_path = pkg_resources.resource_filename('specbox', 'data/')
 
 tb_temp = Table.read(data_path + 'optical_nir_qso_template.fits')
 tb_temp.rename_columns(['wavelength', 'flux'], ['Wave', 'Flux'])
-viewer_version = '1.1'
+viewer_version = '1.2'
 
 class PGSpecPlot(pg.PlotWidget):
     def __init__(self, specfile, SpecClass=SpecEuclid1d, initial_counter=0, z_max=5.0, history_dict=None):

--- a/specbox/qtmodule/qtsir1d.py
+++ b/specbox/qtmodule/qtsir1d.py
@@ -31,8 +31,10 @@ class PGSpecPlot(pg.PlotWidget):
         self.specfile = specfile
         with fits.open(specfile) as hdul:
             self.len_list = len(hdul) - 1
+        if initial_counter >= self.len_list:
+            print("No more spectra to plot.\n\t Plotting the first spectrum.")
+            initial_counter = 0
         self.SpecClass = SpecClass
-        # Use the provided history dictionary (or an empty one)
         self.history = history_dict if history_dict is not None else {}
         self.setWindowTitle("Spectrum")
         self.resize(1200, 800)
@@ -120,7 +122,10 @@ class PGSpecPlot(pg.PlotWidget):
 
     def plot_single(self):
         spec = self.spec
-        if spec.z_vi == 0 and spec.z_ph > 0:
+        # If history contains a saved z_vi for this spectrum, use it.
+        if spec.objid in self.history:
+            spec.z_vi = self.history[spec.objid][4]
+        elif spec.z_vi == 0 and spec.z_ph > 0:
             spec.z_vi = spec.z_ph
         z_vi = spec.z_vi
         z_gaia = spec.z_gaia


### PR DESCRIPTION
This pull request includes several updates and improvements to the `specbox` project, focusing on the build process, versioning, and enhancements to the `qtsir1d.py` module.

### Build process and versioning:
* Added a new GitHub Actions workflow configuration to build the Python package using Conda, including steps for setting up Python, installing dependencies, and linting with flake8. (`.github/workflows/python-package-conda.yml`)
* Updated the package version from `0.1.0-beta` to `0.1.1` in `setup.py`. (`setup.py`)

### Enhancements to `qtsir1d.py` module:
* Updated `viewer_version` from `1.1` to `1.2` and added a check to reset the initial counter if it exceeds the number of spectra. (`specbox/qtmodule/qtsir1d.py`)
* Improved the `plot_single` method to use `z_vi` from history if available. (`specbox/qtmodule/qtsir1d.py`)
* Enhanced `plot_next` and `plot_previous` methods to restore `z_vi` from history if the spectrum object ID is found. (`specbox/qtmodule/qtsir1d.py`) [[1]](diffhunk://#diff-6fc4986b031ca3d028c246df80890bb134272940cbba8ece3d5eb272afd5a6baR176-R177) [[2]](diffhunk://#diff-6fc4986b031ca3d028c246df80890bb134272940cbba8ece3d5eb272afd5a6baR190-R191)
* Modified `keyPressEvent` to handle `Ctrl+R` for resetting the plot with the initial `z_vi` and added key bindings for navigating spectra. (`specbox/qtmodule/qtsir1d.py`)
* Updated the layout instructions in `make_layout` to reflect the new key bindings and functionalities. (`specbox/qtmodule/qtsir1d.py`)