### PR TITLE
minor updates from dev branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ $ vscode settings
 
 $ Mac OS
 .DS_Store
+
+CLAUDE.md

--- a/specbox/qtmodule/__init__.py
+++ b/specbox/qtmodule/__init__.py
@@ -1,4 +1,6 @@
 from .qtmodule import *
 from .qtfelo import *
+from .qtmodule_enhanced import *
 __all__ = []
 __all__ += ['PGSpecPlot', 'PGSpecPlotApp', 'PGSpecPlotThread', 'PGSpecPlotThreadFeLo']
+__all__ += ['PGSpecPlotEnhanced', 'PGSpecPlotAppEnhanced', 'PGSpecPlotThreadEnhanced', 'ImageCutoutWidget']

--- a/specbox/qtmodule/qtsir1d.py
+++ b/specbox/qtmodule/qtsir1d.py
@@ -5,7 +5,7 @@ The functionality of the original ``qtsir1d`` viewer has been merged into
 imports continue to work.
 """
 
-from qtmodule import PGSpecPlot, PGSpecPlotApp, PGSpecPlotThread
+from .qtmodule import PGSpecPlot, PGSpecPlotApp, PGSpecPlotThread
 
 __all__ = ['PGSpecPlot', 'PGSpecPlotApp', 'PGSpecPlotThread']
 


### PR DESCRIPTION
This pull request introduces enhancements to the `specbox/qtmodule` package, primarily by adding new components and improving import statements for better modularity and clarity.

Enhancements to module exports:

* Added `PGSpecPlotEnhanced`, `PGSpecPlotAppEnhanced`, `PGSpecPlotThreadEnhanced`, and `ImageCutoutWidget` to the `__all__` list in `specbox/qtmodule/__init__.py`, making these enhanced classes and widgets available for import from the package.
* Included `qtmodule_enhanced` in the imports of `specbox/qtmodule/__init__.py` to support the new enhanced components.

Import statement improvements:

* Updated the import in `specbox/qtmodule/qtsir1d.py` to use a relative import (`from .qtmodule`) for `PGSpecPlot`, `PGSpecPlotApp`, and `PGSpecPlotThread`, which improves maintainability and avoids potential import errors.